### PR TITLE
Flybys activity

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -844,7 +844,7 @@ function StravaEnhancementSuite($, options) {
 
   // Athlete profile
   $.always(function() {
-    profile_link = $('header .user-menu a');
+    var profile_link = $('header .user-menu a');
     if (
          (profile_link.length === 0)
       || (profile_link.attr('href').indexOf(window.location.pathname) !== 0)
@@ -1292,7 +1292,7 @@ function StravaEnhancementSuite($, options) {
     $(document).ready(function() {
       // Check the "Runs only" / "Rides only" checkbox
       var elem = $('input#hide_different_activity_type');
-      if (elem.checked !== 'on') {
+      if (!elem.prop('checked')) {
         elem.click();
       }
     });

--- a/js/main.js
+++ b/js/main.js
@@ -1289,13 +1289,19 @@ function StravaEnhancementSuite($, options) {
     if (window.location.pathname.indexOf('/flyby/viewer') !== 0) {
       return;
     }
-    $(document).ready(function() {
-      // Check the "Runs only" / "Rides only" checkbox
-      var elem = $('input#hide_different_activity_type');
-      if (!elem.prop('checked')) {
-        elem.click();
+
+    $.setInterval(function() {
+      // Wait until the activities table is loaded before clicking the button.
+      // Strava JS hides a #table_loading div when ready.
+      var activities_loaded = ($('#table_loading').css("display") === 'none');
+      if (activities_loaded) {
+        // Click the "Runs only" / "Rides only" checkbox.
+        $('input#hide_different_activity_type')
+          .onceOnly()
+          .click()
+          ;
       }
-    });
+    }, 1000);
   });
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -844,7 +844,11 @@ function StravaEnhancementSuite($, options) {
 
   // Athlete profile
   $.always(function() {
-    if ($('header .user-menu a').attr('href').indexOf(window.location.pathname) !== 0) {
+    profile_link = $('header .user-menu a');
+    if (
+         (profile_link.length === 0)
+      || (profile_link.attr('href').indexOf(window.location.pathname) !== 0)
+    ) {
       return;
     }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1283,6 +1283,20 @@ function StravaEnhancementSuite($, options) {
       ]);
     });
   });
+
+  // Show same-activity Flybys only (runs or rides) in the Flyby viewer.
+  $.option('show_same_activity_flybys', function() {
+    if (window.location.pathname.indexOf('/flyby/viewer') !== 0) {
+      return;
+    }
+    $(document).ready(function() {
+      // Check the "Runs only" / "Rides only" checkbox
+      var elem = $('input#hide_different_activity_type');
+      if (elem.checked !== 'on') {
+        elem.click();
+      }
+    });
+  });
 }
 
 StravaEnhancementSuite.prototype.switch_units = function() {

--- a/pages/options.js
+++ b/pages/options.js
@@ -235,4 +235,11 @@ var StravaEnhancementSuiteOptions = [
     , "image": false
     , "default": true
   }
+  , {
+      "name": "show_same_activity_flybys"
+    , "title": "Show same-activity Flybys only"
+    , "description": "Show same-activity Flybys only (runs or rides) in the Flyby viewer."
+    , "image": false
+    , "default": false
+  }
 ]


### PR DESCRIPTION
Hi, and thanks much for creating this plugin!

I was wondering whether you'd entertain adding a functionality:

On the Flybys Viewer (in Strava Labs) by default all Flyby activities (whether runs or rides) are shown. I often check Flybys to see who I passed on the way and, as a runner, am almost always interested only in other runners rather than cyclists.

This patch allows auto-clicking of the "Runs only" (or "Rides only"; depends on the activity) checkbox, obviously adding an option for this to the plugin options page.

Also, because the "Athlete Profile" function throws a JS error on pages where there is no user menu, I had to add a check in there, otherwise the plugin fails on pages like Strava Labs.

Thanks for your consideration!

Jeff