### PR TITLE
Fix Repeated segments duplicating hidden efforts

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -917,7 +917,7 @@ function StravaEnhancementSuite($, options) {
     };
   });
 
-  // Repated segments
+  // Repeated segments
   $.option('repeated_segments', function() {
     if (!$.defined('pageView.segmentEfforts')) {
       return;
@@ -927,10 +927,10 @@ function StravaEnhancementSuite($, options) {
     var elevation_unit = null;
 
     // Calculate for both regular and hidden efforts
-    var efforts = $.merge(
-        pageView.segmentEfforts().models
-      , pageView.segmentEfforts().hiddenSegmentEfforts
-    );
+    var efforts = [
+      ...pageView.segmentEfforts().models,
+      ...pageView.segmentEfforts().hiddenSegmentEfforts
+    ]
 
     // Find total raw times by segment ID
     $.each(efforts, function() {


### PR DESCRIPTION
Wow, this one was nasty – one of these bugs that can be fixed with few characters but debugging can (and did) take few hours 😅 Especially when I did not work with jQuery nor Backbone for a looot of years. But to be honest, I quite enjoyed digging in Strava's codebase.

### Description

- jQuery.merge is mutating the first argument (very sneaky IMO) https://api.jquery.com/jquery.merge/ 
- That caused `hiddenSegmentEfforts` to be appended to `models`
- Backbone models exported on window `pageView.segmentEfforts().models` are actually mutable 😱, so it actually mutated the core models (even more sneaky :D)
- When the view was re-rendered, Strava's view layer rendered hidden segments twice.
- BTW, this is even more sneaky (one would think it's not even possible), as Strava frontend JS renders hidden segments **both** from `models` and `hiddenSegmentEfforts` and decides if it's hidden or not by it's own logic, not based on in which model it was stored 

![2020-06-16 09 16 50](https://user-images.githubusercontent.com/697301/84743651-880fd580-afb2-11ea-9bb0-28c2b17ce325.gif)


### Fix

In jQuery docs, it's suggested this to avoid mutating
![image](https://user-images.githubusercontent.com/697301/84743481-51d25600-afb2-11ea-8d80-e0305316f22b.png)

But since modern javascript can merge two arrays easily, I did it natively