### PR TITLE
Fix premium badges

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -544,16 +544,17 @@ function StravaEnhancementSuite($, options) {
 
       $.option('hide_premium_badges', function() {
         // Only keep "Subscriber" line right under the name on athlete's page
-        $([
+        var selectors = [
           '.avatar-badge', // badge over the top-right corner of avatar profiles
           '.badge.premium', // activity page: prefixed to activity name
           '.icon-badge-premium', // suffixed to athlete name
           '.icon-badge-premium', // Club leaderboard
           '.icon-premium' // Card title prefixes (e.g. Relative effort card on dashboard)
-        ].join(', ')).hide()
-
-        // Implementation note: Would be better to do with CSS
-        // to avoid badges flashing for a brief moment until hidden by JS
+        ];
+        $.each(selectors, function(){
+          var newCss = this + '{display:none;}';
+          $('body').append('<style>' + newCss + '</style>');
+        })
       });
 
       $.always(function() {

--- a/js/main.js
+++ b/js/main.js
@@ -1106,16 +1106,18 @@ function StravaEnhancementSuite($, options) {
     onHover('.feed-entry .avatar-md', {
         'width': 80
       , 'height': 80
-      // Use absolute positioning so we don't move stuff out of the way
-      , 'position': 'absolute'
     }, function() {
       $(this)
         // Use a higher-resolution bigger image
         .find('img')
-          .attr('src', function (i, val) {
-            return val.replace('/medium.jpg', '/large.jpg');
-          })
-        ;
+        .attr('src', function (i, val) {
+          return val.replace('/medium.jpg', '/large.jpg');
+        })
+        .css({'width':80,'height':80});
+    }, function(){
+      $(this)
+        .find('img')
+        .css({'width':'','height':''});
     });
 
     // Mouseover on map makes them bigger


### PR DESCRIPTION
fix premium badges, applied css solution as suggested in comment, this also fixes it for the endless scrolling of the feed
fixed sizing of the avatars on hover. image didn't scale up and the name popped behind it.
Removed the position:absolute to prevent the name from popping behind. imho the small "jump" everything makes on sizing feels more natural than the absolute positioning :-)