### PR TITLE
side_by_side_running: optimize & fix

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1044,12 +1044,16 @@ function StravaEnhancementSuite($, options) {
 
   // Show "running" tab by default
   $.option('side_by_side_running', function() {
-    $.setInterval(function() {
-      $('.section.comparison .running-tab')
+    if (!location.pathname.startsWith('/athletes/')) return;
+
+    const selector = '.section.comparison';
+    $(selector).leave('.spinner', function() {
+      $(selector)
+        .find('.running-tab :visible') // :visible will cause not selecting anything when running comparison is already selected
+        .first() // As switcher is duplicated on each tab, and just hidden, it's important to select just the first one to avoid clicking multiple times
         .onceOnly()
-        .click()
-        ;
-    }, 1000);
+        .click();
+    });
   });
 
   // Show the standard Google map, not the terrain one


### PR DESCRIPTION
* Optimized perf (setInterval -> Observer)
* Only run on athlete's profile
* Only click once or never
	* According to feature screenshot, when this feature was originally done, there were just Running & Cycling tabs. Nowadays there is also Swimming, so `.running-tab` button was in DOM two times, so the click happened twice. UI was not broken, as both clicks showed Running tab, but nonetheless the click handler happened twice.
	* Previously, it clicked on running tab also when running tab was already selected
* Hopefully understandable comments :D 